### PR TITLE
Update utils.py

### DIFF
--- a/jbot/bot/utils.py
+++ b/jbot/bot/utils.py
@@ -129,6 +129,10 @@ async def cmd(cmdtext):
             await jdbot.delete_messages(chat_id, msg)
             await jdbot.send_message(chat_id, res)
         elif len(res) > 4000:
+            cmd_temp = re.findall(r"(.*)\.(js|py|ts|sh)",cmdtext)
+            if len(cmd_temp)>0:
+                cmd_temp = f"{cmd_temp[0][0]}.{cmd_temp[0][1]}"
+                cmdtext = cmd_temp
             tmp_log = f'{LOG_DIR}/bot/{cmdtext.split("/")[-1].split(".js")[0]}-{datetime.datetime.now().strftime("%H-%M-%S")}.log'
             with open(tmp_log, 'w+', encoding='utf-8') as f:
                 f.write(res)


### PR DESCRIPTION
青龙环境下面 cmd 参数为多个的时候出现一些问题，会截取到最后一个参数如：
/cmd task jd_video.js https://api.jd.com/index.html
预想情况：jd_video+时间.log 
最终情况：会生成日志 index.html+时间.log 的文件
处理方式：正则提取cmdtext的运行的脚本，然后生成日志
cmd_temp = re.findall(r"(.*)\.(js|py|ts|sh)",cmdtext)
if len(cmd_temp)>0:
         cmd_temp = f"{cmd_temp[0][0]}.{cmd_temp[0][1]}"
         cmdtext = cmd_temp